### PR TITLE
Fix DataFrame Fragmentation warning & Fix wrong arguments parsing

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -105,18 +105,18 @@ if __name__ == "__main__":
         n_features,
         window_size,
         out_dim,
-        kernel_size=args.kernel_size,
-        use_gatv2=args.use_gatv2,
-        feat_gat_embed_dim=args.feat_gat_embed_dim,
-        time_gat_embed_dim=args.time_gat_embed_dim,
-        gru_n_layers=args.gru_n_layers,
-        gru_hid_dim=args.gru_hid_dim,
-        forecast_n_layers=args.fc_n_layers,
-        forecast_hid_dim=args.fc_hid_dim,
-        recon_n_layers=args.recon_n_layers,
-        recon_hid_dim=args.recon_hid_dim,
-        dropout=args.dropout,
-        alpha=args.alpha
+        kernel_size=model_args.kernel_size,
+        use_gatv2=model_args.use_gatv2,
+        feat_gat_embed_dim=model_args.feat_gat_embed_dim,
+        time_gat_embed_dim=model_args.time_gat_embed_dim,
+        gru_n_layers=model_args.gru_n_layers,
+        gru_hid_dim=model_args.gru_hid_dim,
+        forecast_n_layers=model_args.fc_n_layers,
+        forecast_hid_dim=model_args.fc_hid_dim,
+        recon_n_layers=model_args.recon_n_layers,
+        recon_hid_dim=model_args.recon_hid_dim,
+        dropout=model_args.dropout,
+        alpha=model_args.alpha
     )
 
     device = "cuda" if args.use_cuda and torch.cuda.is_available() else "cpu"

--- a/prediction.py
+++ b/prediction.py
@@ -70,11 +70,11 @@ class Predictor:
             actual = actual[:, self.target_dims]
 
         anomaly_scores = np.zeros_like(actual)
-        df = pd.DataFrame()
+        df_dict = {}
         for i in range(preds.shape[1]):
-            df[f"Forecast_{i}"] = preds[:, i]
-            df[f"Recon_{i}"] = recons[:, i]
-            df[f"True_{i}"] = actual[:, i]
+            df_dict[f"Forecast_{i}"] = preds[:, i]
+            df_dict[f"Recon_{i}"] = recons[:, i]
+            df_dict[f"True_{i}"] = actual[:, i]
             a_score = np.sqrt((preds[:, i] - actual[:, i]) ** 2) + self.gamma * np.sqrt(
                 (recons[:, i] - actual[:, i]) ** 2)
 
@@ -85,8 +85,9 @@ class Predictor:
                 a_score = (a_score - median) / (1+iqr)
 
             anomaly_scores[:, i] = a_score
-            df[f"A_Score_{i}"] = a_score
+            df_dict[f"A_Score_{i}"] = a_score
 
+        df = pd.DataFrame(df_dict)
         anomaly_scores = np.mean(anomaly_scores, 1)
         df['A_Score_Global'] = anomaly_scores
 


### PR DESCRIPTION
This proposed pull request solves two issues that come up when running the MTAD-GAT PyTorch model.

[1] During prediction, a series of `PerformanceWarning` messages spams the console. This is due to the fact that in the `prediction.py` file, an empty dataframe is initialized and is then populated with columns and values within a for loop. This is considered a bad practice, hence the warnings that spam the console. Initializing a dictionary object and then casting it into a DataFrame solves the problem.

[2] More importantly, during prediction, the wrong arguments are parsed in the `predict.py` file. More specifically, all model parameters are parsed from the `args` dictionary instead of the `model_args` dictionary. This means one of two things: either the user must specify all model parameters both during training **and** prediction through the console, or if they do not specify them during prediction, then an error does not occur if and only if the model has been trained with the default parameters. Replacing `args` with `model_args` in the specified region of the code solves this problem.