### PR TITLE
Changed bias initialization to avoid NaN errors during training

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -57,7 +57,7 @@ class FeatureAttentionLayer(nn.Module):
         nn.init.xavier_uniform_(self.a.data, gain=1.414)
 
         if self.use_bias:
-            self.bias = nn.Parameter(torch.empty(n_features, n_features))
+            self.bias = nn.Parameter(torch.zeros(n_features, n_features))
 
         self.leakyrelu = nn.LeakyReLU(alpha)
         self.sigmoid = nn.Sigmoid()
@@ -158,7 +158,7 @@ class TemporalAttentionLayer(nn.Module):
         nn.init.xavier_uniform_(self.a.data, gain=1.414)
 
         if self.use_bias:
-            self.bias = nn.Parameter(torch.empty(window_size, window_size))
+            self.bias = nn.Parameter(torch.zeros(window_size, window_size))
 
         self.leakyrelu = nn.LeakyReLU(alpha)
         self.sigmoid = nn.Sigmoid()


### PR DESCRIPTION
Hello again, this is another fix for a common problem presented in the [Issues](https://github.com/ML4ITS/mtad-gat-pytorch/issues) of the mtad-gat-pytorch repository. The `use_bias` parameter of the GAT layers is set to True by default. However, the initialization of the biases is such, that the corresponding Tensors can sometimes fill up with nonsense (due to `torch.empty`), thus leading to NaN values during training. Setting the `use_bias` parameter to False solves the issue of NaNs coming up, but does not allow the user to include biases in their model's architecture. The proposed solution solves both problems, and is also the de-facto approach in other big projects (see the [GATConv](https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/nn/conv/gat_conv.html#GATConv) class from PyG, for example, where `zeros(self.bias)` is written in the `reset_parameters` function, indicating that an initialization of zero for the biases is acceptable).